### PR TITLE
Add weekly sleep quality data to existing chart/ke

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -37,7 +37,7 @@
           <div class="hours-slept"><canvas id=sleepHoursDailyChart width="300" height="300"></canvas></div>
           <div class="quality-of-sleep"><canvas id="sleepQualityDailyChart" width="300" height="300"></canvas></div>
         </div>
-        <div class="user-sleep-week"><canvas id="sleepHoursWeekChart" width="1000" height="500"></canvas></div>
+        <div class="user-sleep-week"><canvas id="sleepHoursandQualityWeekChart" width="1000" height="500"></canvas></div>
         <p class="hidden" id="display-user-sleep-week"></p></div>
         <div class="user-sleep-alltime">All Time:<p class="users-sleep-alltime"></p>
           <div class="hours-slept-alltime">Hours Slept: <p id="sleep-day-hours-alltime"></p></div>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -134,13 +134,13 @@ header {
   height: 12rem;
 }
 
-.flights-of-stairs {
+/* .flights-of-stairs {
   background-color: coral;
-}
+} */
 
-.minutes-active {
+/* .minutes-active {
   background-color: aqua;
-}
+} */
 
 .user-hydration-day,
 .user-hydration-week {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -144,6 +144,26 @@ function fetchUserData() {
         plugins: {
           legend: {
             display: false
+          },
+          tooltip: {
+            callbacks: {
+              label: function(context) {
+                  const datasetIndex = context.datasetIndex;
+                  let label = '';
+                if (datasetIndex === 0 && !label) {
+                  label = context.dataset.label || 'Hours Slept';
+                } else if (datasetIndex === 1 && !label) {
+                  label = context.dataset.label || 'Sleep Quality';
+                }
+                if (label) {
+                  label += ': ';
+                }
+                if (context.parsed.y!== null) {
+                  label += context.parsed.y;
+                }
+                return label;
+              }
+            }
           }
         },
         scales: {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -126,14 +126,19 @@ function fetchUserData() {
         }
       }     
     });
-    new Chart(document.getElementById('sleepHoursWeekChart'), {
+    new Chart(document.getElementById('sleepHoursandQualityWeekChart'), {
       type: 'bar',
       data: {
         labels: sleepHoursWeekDataConverted.map(date => `${date.getMonth() + 1}/${date.getDate()}`),
         datasets: [{
           data: sleepHoursWeekData.map(hours => hours),
           backgroundColor: 'rgba(213, 184, 255)'
-        }]
+        },
+        {
+          data: sleepHoursWeekData.map(hours => hours),
+          backgroundColor: 'rgb(147,112,219)', 
+        }
+      ]
       },
       options: {
         plugins: {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -135,7 +135,7 @@ function fetchUserData() {
           backgroundColor: 'rgba(213, 184, 255)'
         },
         {
-          data: sleepHoursWeekData.map(hours => hours),
+          data: sleepQualityWeekData.map(quality => quality),
           backgroundColor: 'rgb(147,112,219)', 
         }
       ]
@@ -151,7 +151,7 @@ function fetchUserData() {
             display: true,
             title: {
               display: true,
-              text: 'Hours Slept'
+              text: 'Hours Slept and Sleep Quality'
             }
           },
           x: {


### PR DESCRIPTION
### Overview
see below
### Changes 
- Adds second bar for weekly sleep quality data to existing weekly hours slept chart
- When user hovers mouse over each bar, it will have a label corresponding to which dataset the bar is representing. 
- Commented out two CSS selectors in the css file as they were styling divs that no longer exist in the html
### Authors
- Kim Ewing - pekar.kimberly@gmail.com
### Known Issues
- None. 